### PR TITLE
Refactor: mypy Typing

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v1
 
+      - name: Create virtual environment
+        run: python -m venv .venv
+
+      - name: Set VIRTUAL_ENV and PATH
+        run: |
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
       - name: Install project with mypy extras
         run: uv pip install -e .[lint]
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,32 @@
+name: mypy
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  type-check:
+    name: Static type checking (mypy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Install project with mypy extras
+        run: uv pip install -e .[lint]
+
+      - name: Run mypy
+        run: uv run mypy --config-file pyproject.toml

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -37,4 +37,4 @@ jobs:
         run: uv pip install -e .[lint]
 
       - name: Run mypy
-        run: uv run mypy --config-file pyproject.toml
+        run: python -m mypy --config-file pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ wheels/
 # Cache files
 .pytest_cache
 .ruff_cache
+.mypy_cache
 
 # Coverage files
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,15 @@ repos:
       - id: ruff-format
         name: Run Ruff Formatter
         args: [--config=pyproject.toml] # Explicitly specify config file (optional)
+
+  # Optional: mypy type checking pre-commit hook (uses pyproject.toml config)
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.1
+    hooks:
+      - id: mypy
+        name: Run mypy (type checks)
+        additional_dependencies:
+          - numpy
+        args:
+          - --config-file=pyproject.toml
+        files: ^src/ez_animate/.*\.py$

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,8 +61,8 @@ You'll know the environment is active when you see `(.venv)` at the beginning of
 Install the project in "editable" mode along with all development dependencies (for testing, linting, and documentation).
 
 ```bash
-# This command installs ez-animate, pytest, black, ruff, and mkdocs
-uv pip install -e .[test,lint,docs]
+# Recommended: install all dev tools (tests, linting, docs)
+uv pip install -e .[dev]
 ```
 
 **Why this command?**
@@ -71,6 +71,13 @@ uv pip install -e .[test,lint,docs]
 -   `[test,lint,docs]`: These are "extras" defined in our `pyproject.toml`. They install the optional groups of dependencies needed for running tests, checking code style, and building the documentation.
 
 You are now ready to start developing!
+
+Tip: set up pre-commit to run Ruff and mypy locally before each commit:
+
+```bash
+uv run pre-commit install
+uv run pre-commit run --all-files
+```
 
 ## Running Tests
 
@@ -111,6 +118,26 @@ uv run ruff check . --fix
 ```
 
 The CI/CD pipeline will fail if your code is not properly formatted, so it's best to run this before committing.
+
+## Type checking (mypy)
+
+Static type checking is enforced for the library code with mypy. Configuration lives in `pyproject.toml` under `[tool.mypy]` and targets `src/ez_animate` by default.
+
+```bash
+# Ensure lint extras are installed
+uv pip install -e .[lint]
+
+# Run type checks (repository root)
+uv run mypy
+
+# Or explicitly target the package
+uv run mypy src/ez_animate
+```
+
+Notes:
+- The package distributes `py.typed` (PEP 561) and aims for strict-ish typing for public APIs.
+- The NumPy mypy plugin is enabled; `numpy` is already a dependency.
+- Keep new public functions and classes fully typed.
 
 ## Building the Documentation
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
   <a href="https://github.com/charliermarsh/ruff">
     <img src="https://img.shields.io/badge/code%20style-ruff-brightgreen.svg" alt="Code style: ruff">
   </a>
+  <a href="https://mypy-lang.org/">
+    <img src="https://www.mypy-lang.org/static/mypy_badge.svg" alt="Checked with mypy">
+  </a>
   <a href="https://santiagoenriquega.github.io/ez-animate/">
     <img src="https://img.shields.io/website?down_color=red&down_message=offline&up_color=brightgreen&up_message=MkDocs&url=https%3A%2F%2Fsantiagoenriquega.github.io%2Fez-animate" alt="Site Status">
   </a>

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,6 +108,7 @@ ClusteringAnimation(
     model,
     data,
     labels=None,
+    use_true_labels=False,
     test_size=0.3,
     dynamic_parameter=None,
     static_parameters=None,
@@ -126,6 +127,7 @@ ClusteringAnimation(
 - `model`: Clustering model class (e.g., `KMeans`, `DBSCAN`).
 - `data`: Input data for clustering (2D array-like).
 - `labels`: Optional true labels for coloring points (1D array-like or list).
+- `use_true_labels`: Whether to color points by true labels if available (default: False).
 - `test_size`: Fraction of data to use for testing (default: 0.3).
 - `dynamic_parameter`: Parameter to vary dynamically (e.g., `n_clusters`).
 - `static_parameters`: Dictionary of static parameters (e.g., `{'init': 'k-means++'}`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -112,6 +112,25 @@ uv run ruff check . --fix
 
 The CI/CD pipeline will fail if your code is not properly formatted, so it's best to run this before committing.
 
+### Type checking (mypy)
+
+We use mypy for static type checking with a strict-ish configuration defined in `pyproject.toml`.
+
+```bash
+# Install lint extras if not already installed
+uv pip install -e .[lint]
+
+# Run mypy for the repository (defaults to checking src/ez_animate)
+uv run mypy
+
+# Or explicitly target the package
+uv run mypy src/ez_animate
+```
+
+Notes:
+- The package is typed (includes `py.typed`).
+- The NumPy mypy plugin is enabled; `numpy` must be installed (it is in dependencies).
+
 ## Building the Documentation
 
 Our documentation is built with **MkDocs**. This allows you to preview your documentation changes locally before they are published.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 `ez-animate` is compatible with both Scikit-learn and sega_learn models, making it a versatile tool for creating animations of machine learning model behavior. See below for examples of how to use `ez-animate` with different types of models. Or see [API Reference](api.md) for more details on available methods and customization options.
 
-More advanced usage examples can be found in the on [GitHub](https://github.com/SantiagoEnriqueGA/ez-animate/tree/master/examples).
+More advanced usage examples can be found on [GitHub](https://github.com/SantiagoEnriqueGA/ez-animate/tree/master/examples).
 
 
 ## Complete Scikit-learn Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ docs = [
 ]
 lint = [
     "ruff",
+    "mypy>=1.10",
 ]
 
 # Combined 'dev' group for convenience
@@ -148,6 +149,9 @@ convention = "google" # <- Using Google style guide for docstrings (not "numpy" 
 [tool.hatch.build.targets.wheel]
 # Ensure only the package under src is included in the wheel
 packages = ["src/ez_animate"]
+include = [
+    "src/ez_animate/py.typed",
+]
 exclude = [
     "**/__pycache__/**",
     "**/*.py[cod]",
@@ -169,4 +173,36 @@ exclude = [
     "**/*.png",
     "**/*.jpg",
     "**/*.svg",
+]
+
+[tool.mypy]
+# Scope
+files = ["src/ez_animate"]
+mypy_path = ["src"]
+python_version = "3.12"
+
+# Strict-ish defaults aimed at keeping the public surface fully typed
+disallow_untyped_defs = true    # untyped function definitions
+disallow_incomplete_defs = true # incomplete function definitions
+disallow_untyped_calls = true   # untyped function calls
+no_implicit_optional = true     # implicit optionality
+disallow_any_generics = true    # usage of 'Any' in generics
+disallow_subclassing_any = true # subclassing of 'Any'
+check_untyped_defs = true       # untyped function definitions
+implicit_reexport = false       # implicit reexporting of types
+strict_equality = true          # implicit equality checks
+
+# Warnings and ergonomics
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+show_error_codes = true
+pretty = true
+color_output = true
+warn_unused_configs = true
+
+# Plugins
+plugins = [
+    "numpy.typing.mypy_plugin",
 ]

--- a/tests/test_clustering_animation.py
+++ b/tests/test_clustering_animation.py
@@ -307,6 +307,7 @@ class TestClusteringAnimation(BaseTest):
             model=KMeans,
             data=self.X,
             labels=self.y,
+            use_true_labels=True,
             test_size=0.25,
             dynamic_parameter="n_init",
             static_parameters={"n_clusters": 3},
@@ -316,7 +317,6 @@ class TestClusteringAnimation(BaseTest):
             "Clustering",
             "F1",
             "F2",
-            use_true_labels=True,
             legend_loc="upper right",
             grid=True,
         )


### PR DESCRIPTION
# Refactor: Adopt static typing with mypy across the codebase, add CI and pre-commit integration

## Description

This PR introduces static typing throughout the library and sets up type-checking with mypy. It adds precise type annotations across core modules, distributes typing information to users via py.typed, and integrates mypy into both local pre-commit and GitHub Actions CI. Documentation was updated with typing guidance and badges. Minor internal refactors were made to satisfy stricter typing, and a small API tweak was introduced for ClusteringAnimation configuration.

### Key Features
- Comprehensive type hints across src/ez_animate (NumPy typing, Matplotlib artist types, etc.).
- mypy configuration in pyproject.toml with a strict-ish baseline and NumPy plugin.
- mypy enforced in CI via a dedicated GitHub Actions workflow.
- Pre-commit hook to run mypy locally alongside Ruff.
- Package includes py.typed (PEP 561) so downstream users see types.

## Key Changes

1. New Files
    - `.github/workflows/mypy.yml`: New CI workflow to run mypy on pushes and PRs (Python 3.12 with uv).
    - `src/ez_animate/py.typed`: Marks the package as typed for PEP 561.

2. Modified Files
    - `.gitignore`: Add `.mypy_cache` to ignore mypy cache.
    - `.pre-commit-config.yaml`: Add mypy hook (using pyproject config) and ensure numpy dependency.
    - `pyproject.toml`:
      - Add mypy to `[project.optional-dependencies.lint]`.
      - Include `src/ez_animate/py.typed` in wheel build.
      - Add `[tool.mypy]` strict-ish configuration and enable `numpy.typing.mypy_plugin`.
      - Tidy build includes/excludes.
    - `README.md`: Add “Checked with mypy” badge and site badge.
    - `DEVELOPMENT.md` and `docs/contributing.md`: Add a “Type checking (mypy)” section with usage instructions.
    - `docs/api.md`: Document new `use_true_labels` parameter for `ClusteringAnimation` (constructor) and remove it from `setup_plot`.
    - `docs/usage.md`: Minor formatting touch-up.
    - Core modules (type annotations and small refactors for safety/clarity):
      - `src/ez_animate/animation_base.py`: Add explicit attributes (Figure/Axes), safe annotation cleanup, ensure `ani` exists, typed returns, and runtime checks.
      - `src/ez_animate/regression_animation.py`: Use `numpy.typing.NDArray`, annotate Matplotlib artists, safer previous-line handling, runtime asserts.
      - `src/ez_animate/classification_animation.py`: Add `npt.NDArray` types, annotate scatter/contour artists, use modern Matplotlib colormaps, runtime asserts.
      - `src/ez_animate/clustering_animation.py`: Add `use_true_labels` to constructor (replaces `setup_plot` arg), annotate artists, tracing logic made robust, use modern colormaps, runtime asserts.
      - `src/ez_animate/forecasting_animation.py`: Type Line2D artists, assert initialization, refine previous-lines handling.
      - `src/ez_animate/transformation_animation.py`: Type arrays/artists, enforce setup order via asserts, track transformed scatter safely.
      - `src/ez_animate/utils.py`: Tighten types, remove SciPy-specific dependency for split by relying on `shape` presence, improve PCA return typing and use casts.
    - `tests/test_clustering_animation.py`: Update usage to pass `use_true_labels=True` to the constructor and remove it from `setup_plot`.

3. Documentation
    - Add mypy badge to `README.md`.
    - Add mypy setup and commands to `DEVELOPMENT.md` and `docs/contributing.md`.
    - Update `docs/api.md` to reflect `ClusteringAnimation(use_true_labels=...)` constructor parameter.

4. Tests
    - Adjust clustering tests to the new `use_true_labels` constructor parameter.
    - All tests continue to pass locally; type checks pass with configured mypy.

5. Examples
    - No behavioral changes required for examples; API remains the same except for `ClusteringAnimation` setup noted below.

## How to Test

1. Type checks
    - Ensure lint extras are installed, then run mypy from the repo root:
      ```powershell
      uv pip install -e .[lint]
      uv run mypy --config-file pyproject.toml
      ```

2. Unit tests
    - Run the test suite (optionally with coverage):
      ```powershell
      uv run pytest
      # or
      uv run pytest --cov=src/ez_animate --cov-report=term-missing
      ```

3. Pre-commit (optional)
    - To run hooks locally:
      ```powershell
      uv run pre-commit run --all-files
      ```

## Potential Impacts & Considerations

- Breaking Changes: `ClusteringAnimation.setup_plot` no longer accepts `use_true_labels`; pass `use_true_labels` to the constructor instead. Tests and docs updated accordingly.
- Dependencies: mypy added to the `lint` extra; NumPy mypy plugin enabled via pyproject (NumPy already a dependency).
- Performance: No expected runtime impact; changes are largely annotations and minor safety checks.
- Distribution: Package now ships `py.typed` so downstream users get type information.

## Related Issues

- N/A

---

Self-Review Checklist:

- [x] Code adheres to project style guidelines (Ruff).
- [x] Type hints added/updated for new/modified functions and classes.
- [x] Docstrings updated where signatures or behavior changed.
- [x] Corresponding changes to the documentation made (README, guides, API).
- [x] New and existing unit tests pass locally with my changes.
- [x] Type checks (mypy) pass locally with the configured settings.
- [x] Pre-commit hooks run cleanly (Ruff + mypy).
